### PR TITLE
Add 6.0 illuminate/support version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^7",
-        "illuminate/support": "^5.3"
+        "illuminate/support": "^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6",


### PR DESCRIPTION
## Description

Add the illuminate/support version 6.0 to support laravel 6.0

## Motivation and context

I use this package a lot on my generator, such as generating my own repository, etc. But i can't use this package on Laravel 6.0 because of the requirement of this package only support Laravel 5. 

## How has this been tested?

I've been testing it by cloning and doing my autoloading, it works on Laravel 6.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
